### PR TITLE
Fixes a bug relating to unsanitary IPs in prefixes

### DIFF
--- a/src/contracts/IANA.sol
+++ b/src/contracts/IANA.sol
@@ -60,12 +60,9 @@ contract IANA {
         // If their masks are the same
         if (mask1 == mask2) {
             // As are their IPs
-            if (ip1 == ip2) {
+            if ((ip1 >> (32-mask1)) == (ip2 >> (32-mask1))) {
                 // Then they're the same.
                 return PrefixCompareResult.Equal;
-            } else {
-                // Otherwise they can't intersect ever.
-                return PrefixCompareResult.NoIntersection;
             }
         }
         
@@ -86,7 +83,7 @@ contract IANA {
         if (network1 != network2) {
             return PrefixCompareResult.NoIntersection;
         }
-        
+
         // If they reference the same network, it means the bigger one contains the smaller one.
         if (mask1 < mask2) {
             return PrefixCompareResult.OneConatinsTwo;


### PR DESCRIPTION
comparePrefix would regard the prefix 10.0.0.1/8 as not being a part of 10.0.0.0/8. This would allow an attacker to claim a subprefix even though they are (in practice) the same prefix. The intersection code now no longer does direct testing, and only compares the masked prefix.